### PR TITLE
Use interpolation to limit word font sizes based on weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,17 @@ If the property is a function, it will be called with a given word as the first 
 
 ---
 
+`fontSizeRatio`
+
+*type*: `Number`
+
+By default, if we have a word with a weight of 1 and a word with a weight of 500, we can only read the big word, the one are so small that it won't be readable in most cases.
+
+If `fontSizeRatio` is specified, the words' font size will be scaled to respect the given ratio.
+For example, if the ratio equals `5`, this means that the biggest word will be 5 times bigger than the smallest one, improving readability.
+
+---
+
 `animationDuration = 5000`
 
 *type*: `Number`

--- a/VueWordCloud.js
+++ b/VueWordCloud.js
@@ -202,13 +202,47 @@
 			words.sort((word, otherWord) => otherWord.weight - word.weight);
 
 			let minWeight = Iterable_minOf(words, ({weight}) => weight);
-			//let maxWeight = Iterable_maxOf(words, ({weight}) => weight);
-			for (let word of words) {
-				word.weight /= minWeight;
+			let maxWeight = Iterable_maxOf(words, ({weight}) => weight);
+			if (this.fontSizeRatio) {
+				for (let word of words) {
+					word.weight = interpolateWeight(word.weight, [1, this.fontSizeRatio], maxWeight, minWeight);
+				}
+			} else {
+				for (let word of words) {
+					word.weight /= minWeight;
+				}
 			}
 
 			return words;
 		},
+	};
+
+	let interpolateWeight = function (weight, outputRange, maxWeight, minWeight = 1) {
+		const input = weight;
+		const inputMin = minWeight;
+		const inputMax = maxWeight;
+		const inputRange = [inputMin, inputMax];
+		const [outputMin, outputMax] = outputRange;
+
+		if (outputMin === outputMax) {
+			return outputMin;
+		}
+
+		if (inputMin === inputMax) {
+			if (input <= inputMin) {
+				return outputMin;
+			}
+			return outputMax;
+		}
+
+		let result = input;
+
+		// Input Range
+		result = (result - inputMin) / (inputMax - inputMin);
+
+		// Output Range
+		result = result * (outputMax - outputMin) + outputMin;
+		return result;
 	};
 
 	let getBoundedWords = (function() {
@@ -680,6 +714,10 @@
 			color: {
 				type: [String, Function],
 				default: 'Black',
+			},
+
+			fontSizeRatio: {
+				type: Number
 			},
 
 			maxFontSize: {


### PR DESCRIPTION
Hi, first of all great work on this lib !

With the current version, if we have 100 words with a weight of 1 and a word with a weight of 500, we can only read the big word, the 100 other ones are so small that we aren't able to read them.
This may be not be a problem in some cases, but it is in mine.

So I've made a change with this PR so that you can specify min and max font sizes for words. It uses a method based on React Native animation interpolation (https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/Libraries/Animated/src/nodes/AnimatedInterpolation.js#L103-L168).

We give an inputRange `[1, maxWeight]` and an outputRange `[minFontSize, maxFontSize]`. So that the word(s) with a weight equal to `maxWight` have a font size equal to `maxFontSize` and all other words have a size between the given output range.

I force the font size output range to [20, 100] pixels now, but it should be an optional property only for people who want to use it, with specifit min & max font sizes.

Do you have any feedback or do I start implementing props ?