### PR TITLE
fix: Add ESM compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	"license": "MIT",
 	"author": "Sergej Sintschilin <seregpie@gmail.com>",
 	"files": [],
+	"type": "module",
 	"main": "index.js",
 	"repository": "github:SeregPie/VueWordCloud",
 	"scripts": {


### PR DESCRIPTION
> Node.js treats files with a .js extension as ES modules when the nearest parent package.json file contains a top-level "type" field with a value of "module". If the "type" field is not present in the package.json file, or it contains "type": "commonjs", .js files are treated as CommonJS [nodejs.org](https://nodejs.org/api/packages.html).

https://publint.dev/vuewordcloud@19.0.0

Please review and merge this pull request to promote ESM compatibility and improve the package's versatility across different environments. Thanks for your attention.

